### PR TITLE
Configure notifications for stale issues/PRs

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -11,14 +11,13 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@v10
       with:
-        stale-issue-message: 'This issue has been marked as stale due to 60 days of inactivity. To prevent automatic closure in 10 days, remove the stale label or add a comment. You can reopen a closed issue at any time.'
-        stale-pr-message: 'This pull request has been marked as stale due to 60 days of inactivity. To prevent automatic closure in 10 days, remove the stale label or add a comment. You can reopen a closed pull request at any time.'
-        exempt-issue-labels: bug,enhancement
-        exempt-pr-labels: bug,enhancement
-        days-before-stale: 60
-        days-before-close: 10
+        stale-issue-message: '@qualcomm-linux/camera-driver.maint This issue has been marked as stale due to 30 days of inactivity.'
+        stale-pr-message: '@qualcomm-linux/camera-driver.maint This pull request has been marked as stale due to 30 days of inactivity.'
+
+        days-before-stale: 30
+        days-before-close: -1
         remove-stale-when-updated: true
         remove-issue-stale-when-updated: true
         remove-pr-stale-when-updated: true


### PR DESCRIPTION
github-actions: align stale workflow with OSSOps recommendations

This update brings the stale-issues GitHub workflow into alignment with OSSOps-recommended settings. The changes improve the handling of stale issues and pull requests, ensure maintainers are notified when items become stale, and prevent premature closure of open work. These updates help maintain consistent triage behavior across Qualcomm-hosted open-source projects.

Changes included:
- Set a 30-day threshold for marking issues and PRs as stale.
- Notify the appropriate team when an item becomes stale.
- Prevent automatic closure of stale issues and PRs.
- Remove exemption labels, since auto-close is intentionally disabled.
- Improve consistency with Qualcomm open-source automation templates.

These changes enhance project hygiene and ensure the workflow follows Qualcomm’s open-source best practices.